### PR TITLE
remove jsonencode function in terraform resource format

### DIFF
--- a/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.compute/2024-03-02/disks.md
+++ b/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.compute/2024-03-02/disks.md
@@ -630,16 +630,10 @@ resource "azapi_resource" "symbolicname" {
   type = "Microsoft.Compute/disks@2024-03-02"
   name = "string"
   location = "string"
-  sku = {
-    name = "string"
-  }
   tags = {
     {customized property} = "string"
   }
-  zones = [
-    "string"
-  ]
-  body = jsonencode({
+  body = {
     extendedLocation = {
       name = "string"
       type = "string"
@@ -726,7 +720,13 @@ resource "azapi_resource" "symbolicname" {
       supportsHibernation = bool
       tier = "string"
     }
-  })
+    sku = {
+      name = "string"
+    }
+    zones = [
+      "string"
+    ]
+  }
 }
 ```
 ## Property Values

--- a/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.costmanagement/2019-01-01/exports.md
+++ b/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.costmanagement/2019-01-01/exports.md
@@ -487,7 +487,7 @@ resource "azapi_resource" "symbolicname" {
   type = "Microsoft.CostManagement/exports@2019-01-01"
   name = "string"
   parent_id = "string"
-  body = jsonencode({
+  body = {
     properties = {
       definition = {
         dataset = {
@@ -563,7 +563,7 @@ resource "azapi_resource" "symbolicname" {
         status = "string"
       }
     }
-  })
+  }
 }
 ```
 ## Property Values

--- a/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.documentdb/2024-05-15/databaseaccounts.md
+++ b/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.documentdb/2024-05-15/databaseaccounts.md
@@ -878,12 +878,12 @@ resource "azapi_resource" "symbolicname" {
       }
     }
   }
-  kind = "string"
   location = "string"
   tags = {
     {customized property} = "string"
   }
-  body = jsonencode({
+  body = {
+    kind = "string"
     properties = {
       analyticalStorageConfiguration = {
         schemaType = "string"
@@ -987,7 +987,7 @@ resource "azapi_resource" "symbolicname" {
         }
       ]
     }
-  })
+  }
 }
 ```
 ### BackupPolicy objects

--- a/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.keyvault/2023-07-01/vaults.md
+++ b/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.keyvault/2023-07-01/vaults.md
@@ -488,7 +488,7 @@ resource "azapi_resource" "symbolicname" {
   tags = {
     {customized property} = "string"
   }
-  body = jsonencode({
+  body = {
     properties = {
       accessPolicies = [
         {
@@ -543,7 +543,7 @@ resource "azapi_resource" "symbolicname" {
       tenantId = "string"
       vaultUri = "string"
     }
-  })
+  }
 }
 ```
 ## Property Values

--- a/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.resources/2024-07-01/resourcegroups.md
+++ b/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.resources/2024-07-01/resourcegroups.md
@@ -209,14 +209,14 @@ resource "azapi_resource" "symbolicname" {
   type = "Microsoft.Resources/resourceGroups@2024-07-01"
   name = "string"
   location = "string"
-  managedBy = "string"
   tags = {
     {customized property} = "string"
   }
-  body = jsonencode({
+  body = {
+    managedBy = "string"
     properties = {
     }
-  })
+  }
 }
 ```
 ## Property Values

--- a/src/TemplateRefGenerator/Generators/CodeSampleGenerator.cs
+++ b/src/TemplateRefGenerator/Generators/CodeSampleGenerator.cs
@@ -320,7 +320,7 @@ public class CodeSampleGenerator
         return new(mainSample, discriminatedSamples.ToImmutableDictionary());
     }
 
-    private static readonly HashSet<string> TerraformBodyProperties = new(StringComparer.OrdinalIgnoreCase) { "properties", "extendedLocation" };
+    private static readonly HashSet<string> TerraformRootProperties = new(StringComparer.OrdinalIgnoreCase) { "location", "name", "tags", "identity"};
     private static void GenerateTerraform(MarkdownGenerator.ResourceMetadata resource, StringBuilder sb, int indentLevel, TypeBase type, string? path, HashSet<TypeBase> visited)
     {
         if (visited.Contains(type))
@@ -371,7 +371,7 @@ public class CodeSampleGenerator
                     }
                 }
 
-                var bodyProps = props.Where(x => path == "" && TerraformBodyProperties.Contains(x.Key)).ToList();
+                var bodyProps = props.Where(x => path == "" && !TerraformRootProperties.Contains(x.Key)).ToList();
                 foreach (var (name, prop) in props.Except(bodyProps))
                 {
                     AddProperty(name, () => GenerateTerraform(resource, sb, indentLevel + 1, prop.Type.Type, $"{path}.{name}", visited));
@@ -379,12 +379,12 @@ public class CodeSampleGenerator
                 if (bodyProps.Any())
                 {
                     AddProperty("body", () => {
-                        sb.AppendLine($"jsonencode({{");
+                        sb.AppendLine("{");
                         foreach (var (name, prop) in bodyProps)
                         {
                             AddProperty($"  {name}", () => GenerateTerraform(resource, sb, indentLevel + 2, prop.Type.Type, $"{path}.{name}", visited));
                         }
-                        sb.Append($"{propIndent}}})");
+                        sb.Append($"{propIndent}}}");
                     });
                 }
 


### PR DESCRIPTION
This PR made the below changes:
1. Remove `jsonencode` function
2. Move properties like `extendedLocation`, `kind` into `body`. Because only `identity`, `location`, `name` and `tags` should be defined outside `body`.