### PR TITLE
fix terraform identity resource format

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "sdk": {
     "allowPrerelease": false,
-    "version": "8.0.113",
+    "version": "8.0.403",
     "rollForward": "latestPatch"
   }
 }

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "sdk": {
     "allowPrerelease": false,
-    "version": "8.0.403",
+    "version": "8.0.113",
     "rollForward": "latestPatch"
   }
 }

--- a/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.addons/2018-03-01/supportproviders/supportplantypes.md
+++ b/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.addons/2018-03-01/supportproviders/supportplantypes.md
@@ -96,6 +96,7 @@ To create a Microsoft.Addons/supportProviders/supportPlanTypes resource, add the
 resource "azapi_resource" "symbolicname" {
   type = "Microsoft.Addons/supportProviders/supportPlanTypes@2018-03-01"
   name = "string"
+  parent_id = "string"
 }
 ```
 ## Property Values

--- a/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.compute/2024-03-02/disks.md
+++ b/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.compute/2024-03-02/disks.md
@@ -629,6 +629,7 @@ To create a Microsoft.Compute/disks resource, add the following Terraform to you
 resource "azapi_resource" "symbolicname" {
   type = "Microsoft.Compute/disks@2024-03-02"
   name = "string"
+  parent_id = "string"
   location = "string"
   tags = {
     {customized property} = "string"

--- a/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.documentdb/2024-05-15/databaseaccounts.md
+++ b/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.documentdb/2024-05-15/databaseaccounts.md
@@ -880,12 +880,11 @@ To create a Microsoft.DocumentDB/databaseAccounts resource, add the following Te
 resource "azapi_resource" "symbolicname" {
   type = "Microsoft.DocumentDB/databaseAccounts@2024-05-15"
   name = "string"
-  identity = {
+  identity {
     type = "string"
-    userAssignedIdentities = {
-      {customized property} = {
-      }
-    }
+    identity_ids = = [
+      "string"
+    ]
   }
   location = "string"
   tags = {

--- a/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.documentdb/2024-05-15/databaseaccounts.md
+++ b/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.documentdb/2024-05-15/databaseaccounts.md
@@ -882,7 +882,7 @@ resource "azapi_resource" "symbolicname" {
   name = "string"
   identity {
     type = "string"
-    identity_ids = = [
+    identity_ids = [
       "string"
     ]
   }

--- a/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.documentdb/2024-05-15/databaseaccounts.md
+++ b/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.documentdb/2024-05-15/databaseaccounts.md
@@ -880,6 +880,7 @@ To create a Microsoft.DocumentDB/databaseAccounts resource, add the following Te
 resource "azapi_resource" "symbolicname" {
   type = "Microsoft.DocumentDB/databaseAccounts@2024-05-15"
   name = "string"
+  parent_id = "string"
   identity {
     type = "string"
     identity_ids = [

--- a/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.keyvault/2023-07-01/vaults.md
+++ b/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.keyvault/2023-07-01/vaults.md
@@ -484,6 +484,7 @@ To create a Microsoft.KeyVault/vaults resource, add the following Terraform to y
 resource "azapi_resource" "symbolicname" {
   type = "Microsoft.KeyVault/vaults@2023-07-01"
   name = "string"
+  parent_id = "string"
   location = "string"
   tags = {
     {customized property} = "string"

--- a/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.resources/2024-07-01/resourcegroups.md
+++ b/src/TemplateRefGenerator.Tests/Files/markdown/microsoft.resources/2024-07-01/resourcegroups.md
@@ -208,6 +208,7 @@ To create a Microsoft.Resources/resourceGroups resource, add the following Terra
 resource "azapi_resource" "symbolicname" {
   type = "Microsoft.Resources/resourceGroups@2024-07-01"
   name = "string"
+  parent_id = "string"
   location = "string"
   tags = {
     {customized property} = "string"

--- a/src/TemplateRefGenerator/Generators/CodeSampleGenerator.cs
+++ b/src/TemplateRefGenerator/Generators/CodeSampleGenerator.cs
@@ -364,11 +364,7 @@ public class CodeSampleGenerator
                     AddProperty("type", () => sb.Append($"\"{resource.ResourceType}@{resource.ApiVersion}\""));
                     AddProperty("name", () => sb.Append($"\"string\""));
 
-                    if (resource.Type.ScopeType == ScopeType.Unknown ||
-                        resource.Type.ScopeType.HasFlag(ScopeType.Extension))
-                    {
-                        AddProperty("parent_id", () => sb.Append($"\"string\""));
-                    }
+                    AddProperty("parent_id", () => sb.Append($"\"string\""));
 
                     if (props.FirstOrDefault(x => x.Key == "identity") is {} identityProp && identityProp.Key != null)
                     {

--- a/src/TemplateRefGenerator/Generators/CodeSampleGenerator.cs
+++ b/src/TemplateRefGenerator/Generators/CodeSampleGenerator.cs
@@ -369,6 +369,17 @@ public class CodeSampleGenerator
                     {
                         AddProperty("parent_id", () => sb.Append($"\"string\""));
                     }
+
+                    if (props.FirstOrDefault(x => x.Key == "identity") is {} identityProp && identityProp.Key != null)
+                    {
+                        props.Remove(identityProp);
+                        sb.AppendLine("identity {{");
+                        sb.AppendLine($"{propIndent}  type = \"string\"");
+                        sb.AppendLine($"{propIndent}  identity_ids = [");
+                        sb.AppendLine($"{propIndent}    \"string\"");
+                        sb.AppendLine($"{propIndent}  ]");
+                        sb.AppendLine($"{propIndent}}}");
+                    }
                 }
 
                 var bodyProps = props.Where(x => path == "" && !TerraformRootProperties.Contains(x.Key)).ToList();

--- a/src/TemplateRefGenerator/Generators/CodeSampleGenerator.cs
+++ b/src/TemplateRefGenerator/Generators/CodeSampleGenerator.cs
@@ -373,11 +373,12 @@ public class CodeSampleGenerator
                     if (props.FirstOrDefault(x => x.Key == "identity") is {} identityProp && identityProp.Key != null)
                     {
                         props.Remove(identityProp);
-                        sb.AppendLine("identity {{");
-                        sb.AppendLine($"{propIndent}  type = \"string\"");
-                        sb.AppendLine($"{propIndent}  identity_ids = [");
-                        sb.AppendLine($"{propIndent}    \"string\"");
-                        sb.AppendLine($"{propIndent}  ]");
+                        sb.AppendLine($"{propIndent}identity {{");
+                        var nestedPropIndent = GetIndent(indentLevel + 2);
+                        sb.AppendLine($"{nestedPropIndent}type = \"string\"");
+                        sb.AppendLine($"{nestedPropIndent}identity_ids = [");
+                        sb.AppendLine($"{nestedPropIndent}{GetIndent(1)}\"string\"");
+                        sb.AppendLine($"{nestedPropIndent}]");
                         sb.AppendLine($"{propIndent}}}");
                     }
                 }


### PR DESCRIPTION
fixes https://github.com/Azure/bicep-refdocs-generator/issues/80

This PR fixes the `parent_id` and `identity` format in the azapi resource format.